### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ bower install gridlayout
 From [jsDelivr](https://www.jsdelivr.com/projects/gridlayout)
 
 ```
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gridlayout/latest/gridlayout.min.css" />
-<script src="https://cdn.jsdelivr.net/gridlayout/latest/gridlayout-ie.min.js"></script>
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/gridlayout@latest/gridlayout.min.css" />
+<script src="https://cdn.jsdelivr.net/npm/gridlayout@latest/gridlayout-ie.min.js"></script>
 ```
 
 Why use GridLayout?


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/gridlayout.

Feel free to ping me if you have any questions regarding this change.